### PR TITLE
Add i2c in device tree

### DIFF
--- a/board/nationalchip/gx66xx/gx6605s.dts
+++ b/board/nationalchip/gx66xx/gx6605s.dts
@@ -147,6 +147,15 @@
 				linux,default-trigger = "default-on";
 			};
 		};
+
+		i2c@0 {
+			compatible = "i2c-gpio";
+			sda-gpios = <&gpio0 14 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+			scl-gpios = <&gpio0 15 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+			i2c-gpio,delay-us = <2>;	/* ~100 kHz */
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
 	};
 
 	chosen {


### PR DESCRIPTION
在设备树里添加了 I2C 设备。

只要在 Kernel 配置里打开了 I2C bitbanging，就能看到 /dev/i2c-0 了。

    --> Device Drivers
        --> I2C Support
            <*> I2C device interface
            I2C Hardware Bus support  --->
                <*> GPIO-based bitbanging I2C

不知道 Kernel 的配置是作为用户可选项比较好，还是也通过 PR 添加到配置文件里呢？